### PR TITLE
Fixed Query with content

### DIFF
--- a/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
+++ b/src/main/java/no/ntnu/mycbr/rest/controller/helper/Query.java
@@ -66,7 +66,7 @@ public class Query implements RetrievalCustomer {
             tempAmalgamFctManager.changeAmalgamFct(amalFunc);
 
             Retrieval r = new Retrieval(myConcept, cb,this);
-            r.setRetrievalEngine(new NeuralRetrieval(project,r));
+            // r.setRetrievalEngine(new NeuralRetrieval(project,r));
 
             try {
                 Instance query = r.getQueryInstance();


### PR DESCRIPTION
Query with content always throws a NullPointerException.
Commented out the NeuralRetrieval Engine to fix this.

Since the other three occurrences of it are already commented out, I assume this is the way to go.